### PR TITLE
Make the automation more user friendly.

### DIFF
--- a/js/garden.js
+++ b/js/garden.js
@@ -1,8 +1,9 @@
+// Decreasing allows for more automation ticks. Be aware that this might cause performance issues.
+const automation_interval = 100
 
 var colors = ["#f00","#f80","#ff0","#0f0","#0ff","#00f","#f0f","#f00","#f80","#ff0","#0f0","#0ff","#00f","#f0f","#f00","#f80","#ff0","#0f0","#0ff","#00f","#f0f","#f00","#f80"]
 var potato_planted = false
 var growth_progress = 0
-var auto_plant
 var auto_grow = undefined
 var potato_stage = 1
 var potato_stages = [
@@ -99,16 +100,10 @@ function plant() {
 }
 
 function harvest() {
-  if (!document.getElementById("plant_auto").checked) {
-    clearInterval(auto_plant)
-  }
   if (potato_stage == 0 || !potato_planted) {
     return
   }
   if (have_potato == true) {
-    if (document.getElementById("harvest_auto").checked) {
-      setTimeout(harvest, 100)
-    }
     return
   }
   clearInterval(auto_grow)
@@ -117,13 +112,6 @@ function harvest() {
   updatePlotText()
   have_potato = true
   potato_tier = potato_stage
-  if (document.getElementById("make_seeds_auto").checked) {
-    makeSeeds()
-  }
-  if (document.getElementById("plant_auto").checked) {
-    plant()
-    auto_plant = setInterval(plant(),1000) // we keep trying until it works
-  }
   updatePotatoText()
   document.getElementById("plot_progress_bar_vessel").style.background = "#888"
   document.getElementById("plot_progress_bar_bar").style.background = "#f00"
@@ -141,3 +129,22 @@ function harvest() {
     awardAchievement(7,2)
   }
 }
+
+setInterval(function () {
+  if (!document.getElementById("harvest_auto").checked) return
+  if (potato_stage != max_potato_tier) return
+
+  harvest()
+}, automation_interval)
+
+setInterval(function () {
+  if (!document.getElementById("plant_auto").checked) return
+
+  plant()
+}, automation_interval)
+
+setInterval(function() {
+  if (!document.getElementById("make_seeds_auto").checked) return
+
+  makeSeeds()
+}, automation_interval)

--- a/js/inventory.js
+++ b/js/inventory.js
@@ -75,6 +75,9 @@ function saveGame() {
   localStorage.setItem("local_baked_potato_boost",baked_potato_boost)
   localStorage.setItem("local_study_req",study_req)
   localStorage.setItem("local_study_req_cost",study_req_cost)
+
+  localStorage.setItem("automation_harvest_potato_tier", document.getElementById("harvest_auto_setting").value)
+
   console.log("game saved")
 }
 
@@ -145,6 +148,9 @@ function loadGame() {
   if (study_req == 1) {
     document.getElementById("prestige_upgrade_study_req").disabled = "true"
   }
+  
+  document.getElementById("harvest_auto_setting").value = localStorage.getItem("automation_harvest_potato_tier")
+
 }
 
 var warning_triggered = false


### PR DESCRIPTION
When an user unchecks an "auto" checkbox and waits for the slots to be filled up. Ex: There is a potato in the inventory waiting to be converted to seeds. When they check the checkbox the automation does nothing. You have to manually convert the seed the first time for it to kick back into action.

- Fix the issue with the automation.
- Saves the minimum potato tier when the game saves so it does not default back to 0. 